### PR TITLE
Apply Python 3 encoding for subprocess output

### DIFF
--- a/rplugin/python3/denite/source/gitstatus.py
+++ b/rplugin/python3/denite/source/gitstatus.py
@@ -45,16 +45,16 @@ def _parse_line(line, root):
         'source__tree': tree_symbol not in [' ', '?']
     }
 
-def run_command(commands, cwd):
+def run_command(commands, cwd, encoding='utf-8'):
     try:
         p = subprocess.run(commands,
                            cwd=cwd,
-                           encoding="utf8",
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError:
         return []
-    return p.stdout.split('\n')
+
+    return p.stdout.decode(encoding).split('\n')
 
 class Source(Base):
 


### PR DESCRIPTION
Fix error of 'encoding' keyword isn't supported by `subprocess.run`:

```
[denite]   File "/Users/rafi/.cache/vim/dein/repos/github.com/Shougo/denite.nvim/rpl
ugin/python3/denite/denite.py", line 66, in _gather_source_candidates
[denite]     candidates = source.gather_candidates(context)
[denite]   File "/Users/rafi/.cache/vim/dein/repos/github.com/chemzqm/denite-git/rpl
ugin/python3/denite/source/gitstatus.py", line 98, in gather_candidates
[denite]     lines = run_command(args, root)
[denite]   File "/Users/rafi/.cache/vim/dein/repos/github.com/chemzqm/denite-git/rpl
ugin/python3/denite/source/gitstatus.py", line 54, in run_command
[denite]     stderr=subprocess.STDOUT)
[denite]   File "/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/pyt
hon3.5/subprocess.py", line 383, in run
[denite]     with Popen(*popenargs, **kwargs) as process:
[denite] TypeError: __init__() got an unexpected keyword argument 'encoding'
[denite] Please execute :messages command.
```