### PR TITLE
Use path of current buffer for cwd

### DIFF
--- a/rplugin/python3/denite/source/gitlog.py
+++ b/rplugin/python3/denite/source/gitlog.py
@@ -57,7 +57,7 @@ class Source(Base):
         context['__proc'] = None
 
         args = dict(enumerate(context['args']))
-        cwd = os.path.normpath(self.vim.call('getcwd'))
+        cwd = os.path.normpath(self.vim.eval('expand("%:p:h")'))
 
         is_all = str(args.get(0, [])) == 'all'
         context['pattern'] = context['input'] if context['input'] else str(args.get(1, ''))

--- a/rplugin/python3/denite/source/gitstatus.py
+++ b/rplugin/python3/denite/source/gitstatus.py
@@ -166,7 +166,7 @@ class Kind(File):
 
 
     def action_reset(self, context):
-        cwd = os.path.normpath(self.vim.call('getcwd'))
+        cwd = os.path.normpath(self.vim.eval('expand("%:p:h")'))
         for target in context['targets']:
             filepath = target['action__path']
             root = target['source__root']

--- a/rplugin/python3/denite/source/gitstatus.py
+++ b/rplugin/python3/denite/source/gitstatus.py
@@ -68,7 +68,7 @@ class Source(Base):
         self.kind = Kind(vim)
 
     def on_init(self, context):
-        cwd = os.path.normpath(self.vim.call('getcwd'))
+        cwd = os.path.normpath(self.vim.eval('expand("%:p:h")'))
 
         context['__root'] = _find_root(cwd)
 


### PR DESCRIPTION
This is to replicate the behaviour of other git plugins for vim which
give have the git context of the current buffer, rather than the global
cwd of vim.