### PR TITLE
Fold preview only for gitlog:all

### DIFF
--- a/rplugin/python3/denite/source/gitlog.py
+++ b/rplugin/python3/denite/source/gitlog.py
@@ -212,4 +212,6 @@ class Kind(Openable):
         self.vim.call('easygit#show', commit, option)
         self.vim.command('set previewwindow')
         self.vim.command('wincmd P')
+        if not is_all:
+            self.vim.command('set nofen')
         self.vim.call('win_gotoid', prev_id)


### PR DESCRIPTION
gitlog scope is a single file, so a folded preview looks like:
```
commit 33fb588145d37432f6bd14dff309a121f9ff6225
parent 
author BonaBeavis <> Wed May 2 18:41:41 2018 +0200
committer BonaBeavis <> Wed May 2 18:41:41 2018 +0200
 

Initial commit


 7+ 0- README.md
```
I already know that README.md was changed. With this commit the preview will show what was changed.