### PR TITLE
Allow git submodules 

### DIFF
--- a/autoload/denite/git.vim
+++ b/autoload/denite/git.vim
@@ -2,7 +2,7 @@
 function! denite#git#gitdir() abort
   let gitdir = get(b:, 'git_dir', '')
   if !empty(gitdir) | return gitdir | endif
-  let path = (empty(bufname('%')) || &buftype =~# '^\%(nofile\|acwrite\|quickfix\|terminal\)$')) ? getcwd() : expand('%:p')
+  let path = (empty(bufname('%')) || &buftype =~# '^\%(nofile\|acwrite\|quickfix\|terminal\)$') ? getcwd() : expand('%:p')
   let dir = finddir('.git', path.';')
   if empty(dir) | return '' | endif
   let files = findfile('.git', path.';',-1)

--- a/autoload/denite/git.vim
+++ b/autoload/denite/git.vim
@@ -2,10 +2,12 @@
 function! denite#git#gitdir() abort
   let gitdir = get(b:, 'git_dir', '')
   if !empty(gitdir) | return gitdir | endif
-  let path = empty(bufname('%')) ? getcwd() : expand('%:p')
+  let path = (empty(bufname('%')) || &buftype =~# '^\%(nofile\|acwrite\|quickfix\|terminal\)$')) ? getcwd() : expand('%:p')
   let dir = finddir('.git', path.';')
+  let files = findfile('.git', path.';',-1)
   if empty(dir) | return '' | endif
-  return fnamemodify(dir, ':p:h')
+  if empty(files) | return fnamemodify(dir, ':p:h') | endif
+  return fnamemodify(remove(files,-1), ':p:h')
 endfunction
 
 function! denite#git#commit(prefix, files) abort

--- a/autoload/denite/git.vim
+++ b/autoload/denite/git.vim
@@ -7,7 +7,7 @@ function! denite#git#gitdir() abort
   if empty(dir) | return '' | endif
   let files = findfile('.git', path.';',-1)
   if empty(files) | return fnamemodify(dir, ':p:h') | endif
-  return fnamemodify(remove(files,-1), ':p:h')
+  return fnamemodify(files[-1], ':p')
 endfunction
 
 function! denite#git#commit(prefix, files) abort

--- a/autoload/denite/git.vim
+++ b/autoload/denite/git.vim
@@ -4,8 +4,8 @@ function! denite#git#gitdir() abort
   if !empty(gitdir) | return gitdir | endif
   let path = (empty(bufname('%')) || &buftype =~# '^\%(nofile\|acwrite\|quickfix\|terminal\)$')) ? getcwd() : expand('%:p')
   let dir = finddir('.git', path.';')
-  let files = findfile('.git', path.';',-1)
   if empty(dir) | return '' | endif
+  let files = findfile('.git', path.';',-1)
   if empty(files) | return fnamemodify(dir, ':p:h') | endif
   return fnamemodify(remove(files,-1), ':p:h')
 endfunction

--- a/rplugin/python3/denite/source/gitstatus.py
+++ b/rplugin/python3/denite/source/gitstatus.py
@@ -17,6 +17,7 @@ EMPTY_LINE = re.compile(r"^\s*$")
 STATUS_MAP = {
     ' ': ' ',
     'M': '~',
+    'T': '~',
     'A': '+',
     'D': '-',
     'R': '→',


### PR DESCRIPTION
- where there is a .git file ( for a sub module ) return that as the directory in gitdir rather than the root git directory
- added T status ( where the file type has changed ) which was missing from the status map and caused an error