### PR TITLE
Updated denite util input calls

### DIFF
--- a/rplugin/python3/denite/source/gitbranch.py
+++ b/rplugin/python3/denite/source/gitbranch.py
@@ -92,14 +92,18 @@ class Kind(BaseKind):
 
         if target['source__remote']:
             branchname = branch.split('/')[-1]
-            confirm = util.input(
-                    self.vim, context, 'Delete remote branch '
-                    + branchname + '? [y/n] : ', 'n') == 'y'
+
+            confirm = str(self.vim.call('denite#util#input',
+                            'Delete remote branch ' + branchname + '? [y/n] : ',
+                            'n',
+                            '')) == 'y'
             if confirm:
                 args = ['git', 'push', 'origin', '--delete', branchname]
         else:
-            force = util.input(
-                    self.vim, context, 'Force delete? [y/n] : ', 'n') == 'y'
+            force = str(self.vim.call('denite#util#input',
+                            'Force delete? [y/n] : ',
+                            'n',
+                            '')) == 'y'
             args = ['git', 'branch', '-D' if force else '-d', branch]
 
         if len(args) > 0:

--- a/rplugin/python3/denite/source/gitlog.py
+++ b/rplugin/python3/denite/source/gitlog.py
@@ -158,7 +158,10 @@ class Kind(Openable):
         commit = target['source__commit']
         gitdir = target['source__gitdir']
 
-        c = util.input(self.vim, context, 'Reset mode mixed|soft|hard [m/s/h]: ')
+        c = str(self.vim.call('denite#util#input',
+                        'Reset mode mixed|soft|hard [m/s/h]: ',
+                        '',
+                        ''))
         opt = ''
         if c == 'm':
             opt = '--mixed'

--- a/rplugin/python3/denite/source/gitstatus.py
+++ b/rplugin/python3/denite/source/gitstatus.py
@@ -163,7 +163,11 @@ class Kind(File):
         prefix = ''
         if target['source__staged']:
             if target['source__tree']:
-                if util.input(self.vim, context, 'Diff cached?[y/n]', 'y') == 'y':
+                confirmed = str(self.vim.call('denite#util#input',
+                                'Diff cached?[y/n]',
+                                'y',
+                                '')) == 'y'
+                if confirmed == 'y':
                     prefix = '--cached '
             else:
                 prefix = '--cached '
@@ -181,7 +185,10 @@ class Kind(File):
             root = target['source__root']
             path = os.path.relpath(filepath, root)
             if target['source__tree'] and target['source__staged']:
-                res = util.input(self.vim, context, 'Select action reset or checkout [r/c]')
+                res = str(self.vim.call('denite#util#input',
+                                'Select action reset or checkout [r/c]',
+                                '',
+                                ''))
                 if res == 'c':
                     args = 'git checkout -- ' + path
                     run_command(shlex.split(args), root)


### PR DESCRIPTION
Some actions used denite's util.input function. This function was removed in this [commit](https://github.com/Shougo/denite.nvim/commit/4af5416f58573f166db918a7f9dd4e8f7b4898eb#diff-310bf3f97f2cc2a2fc184f4668e968b9).

The sources' function calls to input() have been changed to suit.