### PR TITLE
Detect the root from git command

### DIFF
--- a/autoload/denite/git.vim
+++ b/autoload/denite/git.vim
@@ -10,6 +10,14 @@ function! denite#git#gitdir() abort
   return fnamemodify(files[-1], ':p')
 endfunction
 
+function! denite#git#root(gitdir) abort
+  let out = systemlist('git --git-dir='.a:gitdir.' rev-parse --show-toplevel')
+  if v:shell_error
+    return v:null
+  endif
+  return out[0]
+endfunction
+
 function! denite#git#commit(prefix, files) abort
   if get(g:, 'loaded_fugitive', 0)
     execute 'Gcommit '.a:prefix .' ' . join(map(a:files, 'fnameescape(v:val)'), ' ')

--- a/rplugin/python3/denite/source/gitbranch.py
+++ b/rplugin/python3/denite/source/gitbranch.py
@@ -48,7 +48,7 @@ class Source(BaseSource):
 
     def on_init(self, context):
         gitdir = self.vim.call('denite#git#gitdir')
-        context['__root'] = '' if not gitdir else os.path.dirname(gitdir)
+        context['__root'] = self.vim.call('denite#git#root', gitdir)
 
     def gather_candidates(self, context):
         root = context['__root']

--- a/rplugin/python3/denite/source/gitfiles.py
+++ b/rplugin/python3/denite/source/gitfiles.py
@@ -37,7 +37,7 @@ class Source(BaseSource):
         args = dict(enumerate(context['args']))
         branch = str(args.get(0, "master"))
         gitdir = self.vim.call('denite#git#gitdir')
-        context['__root'] = '' if not gitdir else os.path.dirname(gitdir)
+        context['__root'] = self.vim.call('denite#git#root', gitdir)
         context['__branch'] = branch
 
     def gather_candidates(self, context):


### PR DESCRIPTION
Fix #17

`denite#git#gitdir()` searches a `.git` dir or file, or re-uses `b:git_dir` variable to return the value.

[vim-fugitive][] also uses this variable to store the gitdir, but the value is different from `denite#git#gitdir()`. It stores a directory even if it is in submodules.

[vim-fugitive]: https://github.com/tpope/vim-fugitive

```sh
/--- .git (dir)              # main gitdir  
  |   +-- modules
  |        +-- my_submodule  # true gitdir for submodules
  |                          #   (value from vim-futivie)
  +- my_submodule            # submodule
      +-- .git (file)        # a file indicating the true gitdir
                             #   (value from denite#git#gitdir)
```

In an example above, the content of `/my_submodule/.git` is `gitdir: ../.git/modules/my_submodule`.

The current master calculates the repo root from gitdir, simply it regards the parent dir as the root. It is a valid estimate when `b:git_dir` is derived from `denite#git#gitdir()`, but once vim-fugitive overwrites `b:git_dir`, denite-git loses sight of the repo root.

----

This PR solves this. I wrote `denite#git#root()` to calculate the repo root by the command: `git rev-parse --short-toplevel`. This works in common git repos and even in submodules.