### PR TITLE
Use redundant parens to avoid fielpath expansion

### DIFF
--- a/autoload/denite/git.vim
+++ b/autoload/denite/git.vim
@@ -54,7 +54,7 @@ function! denite#git#diffCurrent(revision, option) abort
   let list = split(output, '\v\r?\n')
   if !len(list)| diffoff | return | endif
   diffthis
-  execute 'keepalt '.edit.' +setl\ buftype=nofile [Git '.a:revision.']'
+  execute 'keepalt '.edit.' +setl\ buftype=nofile [[Git '.a:revision.']]'
   call setline(1, list[0])
   silent! call append(1, list[1:])
   execute 'setf ' . ft
@@ -84,7 +84,7 @@ function! denite#git#show(args, option)
   let output = system(command)
   let list = split(output, '\v\r?\n')
   if !len(list)| return | endif
-  execute 'keepalt '.edit.' +setl\ buftype=nofile [Git '.a:args.']'
+  execute 'keepalt '.edit.' +setl\ buftype=nofile [[Git '.a:args.']]'
   call setline(1, list[0])
   silent! call append(1, list[1:])
   setlocal filetype=git foldmethod=syntax readonly bufhidden=wipe


### PR DESCRIPTION
In previous commit, `diffCurrent()` and `show()` opens a buffer named
`[Git foobar]`. This name also means files/directories named each one
character `G`, `i`, `t`, and so on.

For example, when the current dir has a directory named `t`, `show()`
opens the `t` directory and raises annoying errors.

This commit changes the name to `[[Git foobar]]` and avoids such
unnecessary filepath expansions.